### PR TITLE
Added skill class portions

### DIFF
--- a/Python/7CountryAlphaV3/Main.py
+++ b/Python/7CountryAlphaV3/Main.py
@@ -15,7 +15,11 @@ def Multi_Country(S,I,J,sigma):
 
     #Country Rosters
     I_dict = {"usa":0,"eu":1,"japan":2,"china":3,"india":4,"russia":5,"korea":6} #DONT CHANGE
+    I_HighSkill = np.array([.7,.7,.7,.75,.75,.7,.7]) #CAN CHANGE
     I_touse = ["eu","russia","usa","japan","korea","china","india"] #CAN CHANGE
+
+    #NOTE: I_HighSkill sets the portion of each country's population that's deemed 
+    #      "high skill". The remaining portion will be divided equally among the remaining classes.
 
     #Parameters Zone
     g_A = 0.015 #Technical growth rate
@@ -24,6 +28,7 @@ def Multi_Country(S,I,J,sigma):
     alpha = .3 #Capital Share of production
     chi = 1.5 #Preference for lesiure
     rho = .4 #Intratemporal elasticity of substitution
+
 
     #Convergence Tolerances
     demog_ss_tol = 1e-8 #Used in getting ss for population share
@@ -57,15 +62,17 @@ def Multi_Country(S,I,J,sigma):
         if len(I_touse) < I:
             print "WARNING: We are changing I from", I, "to", len(I_touse), "to fit the length of I_touse. So the countries we are using now are", I_touse
             I = len(I_touse)
+            I_HighSkill_touse = I_HighSkill[:I]
             time.sleep(2)
 
         elif len(I_touse) > I:
             print "WARNING: We are changing I_touse from", I_touse, "to", I_touse[:I], "so there are", I, "regions"
             I_touse = I_touse[:I]
+            I_HighSkill_touse = I_HighSkill[:I]
             time.sleep(2)
 
     ##INPUTS INTO THE CLASS###
-    Country_Roster = (I_dict, I_touse)
+    Country_Roster = (I_dict, I_touse,I_HighSkill_touse)
 
     HH_params = (S,I,J,beta_ann,sigma)
 


### PR DESCRIPTION
Thanks to James for pointing this out, but I have now added putting in skill class portions into the code. On Main.py line 18, the user indicates how much of the population is in the high skill class. Since this code is intended to work with J classes, I kept it simple: The high class has the user indicated portion of the population, while the rest of the classes have equal portions of what's left.

The difficulty was coming up with a rule of how to divide the remaining portion automatically without the user having to specify each class portion directly. We can adjust this later, but I thought it would be the most useful if someone decided to use J>2.

So, if there are three skill classes and the user sets the portion of the high class to be 1/2 of the population, then class 2 and 3 each get 1/4 of the population.

The population matrix is now corrected to indicate this portions. Note that I still haven't fixed the problem that I brought up in the last pull request, namely, line 377 in AuxiliaryClass.py
